### PR TITLE
Switch to node-fetch from Axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@sapphire/async-queue": "^1.1.4",
-                "axios": "^0.21.1",
                 "ms": "^2.1.3",
+                "node-fetch": "^2.6.7",
                 "update-notifier": "^5.1.0"
             },
             "devDependencies": {
@@ -162,14 +162,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "node_modules/axios": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-            "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -592,25 +584,6 @@
             "dev": true,
             "bin": {
                 "flat": "cli.js"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.14.8",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-            "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
             }
         },
         "node_modules/fs.realpath": {
@@ -1143,6 +1116,25 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1517,6 +1509,11 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "node_modules/type-fest": {
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -1596,6 +1593,20 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -1841,14 +1852,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "axios": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-            "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
-            "requires": {
-                "follow-redirects": "^1.14.0"
-            }
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -2163,11 +2166,6 @@
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true
-        },
-        "follow-redirects": {
-            "version": "1.14.8",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-            "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -2548,6 +2546,14 @@
             "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "dev": true
         },
+        "node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2815,6 +2821,11 @@
                 "is-number": "^7.0.0"
             }
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "type-fest": {
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -2869,6 +2880,20 @@
             "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
             "requires": {
                 "prepend-http": "^2.0.0"
+            }
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     },
     "dependencies": {
         "@sapphire/async-queue": "^1.1.4",
-        "axios": "^0.21.1",
         "ms": "^2.1.3",
+        "node-fetch": "^2.6.7",
         "update-notifier": "^5.1.0"
     },
     "engines": {

--- a/src/errors/APIError.js
+++ b/src/errors/APIError.js
@@ -6,11 +6,11 @@
  */
 
 class APIError extends Error {
-    constructor(response) {
+    constructor(response, data) {
         super();
         this.name = this.constructor.name;
         this.status = response.status;
-        this.message = response.data ? response.data.error : undefined
+        this.message = data ? data.error : undefined
     }
 }
 

--- a/src/errors/RatelimitError.js
+++ b/src/errors/RatelimitError.js
@@ -9,11 +9,11 @@ const ms = require("ms")
  */
 
 class RatelimitError extends Error {
-    constructor(response) {
+    constructor(response, data) {
         super();
         this.name = this.constructor.name;
         this.status = response.status;
-        this.remaining = response.data["Ratelimit-Remaining"]
+        this.remaining = data["Ratelimit-Remaining"]
         this.message = 'You are currently ratelimited! Try again in ' + ms(this.remaining)
     }
 }


### PR DESCRIPTION
The Axios library has been causing issues, namely throwing errors on timeout that can't be caught. This pull request implements a change to node-fetch, which also will make it easier to switch to the built-in fetch api when we update to v18.

I wasn't able to test every possible API response, it passes all the tests in the test file, but that doesn't test for issues like ratelimiting and other issues. I tested it against a 429 response, and it worked.