### PR TITLE
Remove update-notifier because it has vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
             "dependencies": {
                 "@sapphire/async-queue": "^1.1.4",
                 "ms": "^2.1.3",
-                "node-fetch": "^2.6.7",
-                "update-notifier": "^5.1.0"
+                "node-fetch": "^2.6.7"
             },
             "devDependencies": {
                 "docdash": "^1.2.0",
@@ -35,83 +34,11 @@
                 "npm": ">=6"
             }
         },
-        "node_modules/@sindresorhus/is": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-            "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-            "dependencies": {
-                "defer-to-connect": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@ungap/promise-all-settled": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
-        },
-        "node_modules/ansi-align": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-            "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-            "dependencies": {
-                "string-width": "^3.0.0"
-            }
-        },
-        "node_modules/ansi-align/node_modules/ansi-regex": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-            "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/ansi-align/node_modules/emoji-regex": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-        },
-        "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/ansi-align/node_modules/string-width": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-            "dependencies": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/ansi-align/node_modules/strip-ansi": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-            "dependencies": {
-                "ansi-regex": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/ansi-colors": {
             "version": "4.1.1",
@@ -126,6 +53,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -134,6 +62,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -178,27 +107,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/boxen": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
-            "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
-            "dependencies": {
-                "ansi-align": "^3.0.0",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.1.0",
-                "cli-boxes": "^2.2.1",
-                "string-width": "^4.2.0",
-                "type-fest": "^0.20.2",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -227,49 +135,11 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "node_modules/cacheable-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-            "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^3.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^4.1.0",
-                "responselike": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/camelcase": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
             "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -281,6 +151,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -296,6 +167,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -330,22 +202,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-        },
-        "node_modules/cli-boxes": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-            "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -357,18 +213,11 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
-        "node_modules/clone-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -379,37 +228,14 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
-        },
-        "node_modules/configstore": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-            "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-            "dependencies": {
-                "dot-prop": "^5.2.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^3.0.0",
-                "unique-string": "^2.0.0",
-                "write-file-atomic": "^3.0.0",
-                "xdg-basedir": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/crypto-random-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/debug": {
             "version": "4.3.3",
@@ -446,30 +272,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/decompress-response": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
-        },
         "node_modules/diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -485,34 +287,11 @@
             "integrity": "sha512-IYZbgYthPTspgqYeciRJNPhSwL51yer7HAwDXhF5p+H7mTDbPvY3PCk/QDjNxdPCpWkaJVFC4t7iCNB/t9E5Kw==",
             "dev": true
         },
-        "node_modules/dot-prop": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-            "dependencies": {
-                "is-obj": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -521,14 +300,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/escape-goat": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
-            "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -615,17 +386,6 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -658,46 +418,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/global-dirs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-            "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-            "dependencies": {
-                "ini": "2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/got": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "dependencies": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
         "node_modules/growl": {
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -711,14 +431,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/has-yarn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-            "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -730,27 +443,6 @@
             "dev": true,
             "bin": {
                 "he": "bin/he"
-            }
-        },
-        "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
-        "node_modules/import-lazy": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "engines": {
-                "node": ">=0.8.19"
             }
         },
         "node_modules/inflight": {
@@ -769,14 +461,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "node_modules/ini": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -787,17 +471,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-            "dependencies": {
-                "ci-info": "^2.0.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
             }
         },
         "node_modules/is-extglob": {
@@ -813,6 +486,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -829,32 +503,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-installed-globally": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-            "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-            "dependencies": {
-                "global-dirs": "^3.0.0",
-                "is-path-inside": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-npm": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
-            "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -862,22 +510,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-obj": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -888,11 +520,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
@@ -905,11 +532,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is-yarn-global": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-            "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -927,30 +549,6 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/json-buffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-        },
-        "node_modules/keyv": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-            "dependencies": {
-                "json-buffer": "3.0.0"
-            }
-        },
-        "node_modules/latest-version": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-            "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-            "dependencies": {
-                "package-json": "^6.3.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/locate-path": {
@@ -984,55 +582,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lowercase-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/minami": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/minami/-/minami-1.2.3.tgz",
@@ -1050,11 +599,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "node_modules/mocha": {
             "version": "9.2.0",
@@ -1144,28 +688,13 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-            "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/p-limit": {
@@ -1198,28 +727,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/package-json": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-            "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-            "dependencies": {
-                "got": "^9.6.0",
-                "registry-auth-token": "^4.0.0",
-                "registry-url": "^5.0.0",
-                "semver": "^6.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/package-json/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1250,34 +757,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/prepend-http": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "node_modules/pupa": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
-            "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
-            "dependencies": {
-                "escape-goat": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1285,33 +764,6 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "node_modules/rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "node_modules/rc/node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-        },
-        "node_modules/rc/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/readdirp": {
@@ -1326,28 +778,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/registry-auth-token": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-            "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
-            "dependencies": {
-                "rc": "^1.2.8"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/registry-url": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-            "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-            "dependencies": {
-                "rc": "^1.2.8"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1355,14 +785,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/responselike": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-            "dependencies": {
-                "lowercase-keys": "^1.0.0"
             }
         },
         "node_modules/safe-buffer": {
@@ -1385,39 +807,6 @@
                 }
             ]
         },
-        "node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/semver-diff": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-            "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-            "dependencies": {
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/semver-diff/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/serialize-javascript": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -1427,15 +816,11 @@
                 "randombytes": "^2.1.0"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        },
         "node_modules/string-width": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
             "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -1449,6 +834,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
             "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.0"
             },
@@ -1489,14 +875,6 @@
             "integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ=",
             "dev": true
         },
-        "node_modules/to-readable-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1514,25 +892,6 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dependencies": {
-                "is-typedarray": "^1.0.0"
-            }
-        },
         "node_modules/typescript": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
@@ -1544,55 +903,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/unique-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-            "dependencies": {
-                "crypto-random-string": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/update-notifier": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
-            "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
-            "dependencies": {
-                "boxen": "^5.0.0",
-                "chalk": "^4.1.0",
-                "configstore": "^5.0.1",
-                "has-yarn": "^2.1.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^2.0.0",
-                "is-installed-globally": "^0.4.0",
-                "is-npm": "^5.0.0",
-                "is-yarn-global": "^0.3.0",
-                "latest-version": "^5.1.0",
-                "pupa": "^2.1.1",
-                "semver": "^7.3.4",
-                "semver-diff": "^3.1.1",
-                "xdg-basedir": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/yeoman/update-notifier?sponsor=1"
-            }
-        },
-        "node_modules/url-parse-lax": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-            "dependencies": {
-                "prepend-http": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/webidl-conversions": {
@@ -1624,17 +934,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/widest-line": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-            "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-            "dependencies": {
-                "string-width": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/workerpool": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
@@ -1645,6 +944,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -1660,26 +960,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "node_modules/write-file-atomic": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "is-typedarray": "^1.0.0",
-                "signal-exit": "^3.0.2",
-                "typedarray-to-buffer": "^3.1.5"
-            }
-        },
-        "node_modules/xdg-basedir": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-            "engines": {
-                "node": ">=8"
-            }
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -1689,11 +971,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -1756,67 +1033,11 @@
             "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz",
             "integrity": "sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA=="
         },
-        "@sindresorhus/is": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
-        },
-        "@szmarczak/http-timer": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-            "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-            "requires": {
-                "defer-to-connect": "^1.0.1"
-            }
-        },
         "@ungap/promise-all-settled": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
-        },
-        "ansi-align": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-            "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-            "requires": {
-                "string-width": "^3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-                    "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
-                },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                }
-            }
         },
         "ansi-colors": {
             "version": "4.1.1",
@@ -1827,12 +1048,14 @@
         "ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true
         },
         "ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "requires": {
                 "color-convert": "^2.0.1"
             }
@@ -1865,21 +1088,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
-        "boxen": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
-            "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
-            "requires": {
-                "ansi-align": "^3.0.0",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.1.0",
-                "cli-boxes": "^2.2.1",
-                "string-width": "^4.2.0",
-                "type-fest": "^0.20.2",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1905,44 +1113,17 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "cacheable-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-            "requires": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^3.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^4.1.0",
-                "responselike": "^1.0.2"
-            },
-            "dependencies": {
-                "get-stream": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
-                "lowercase-keys": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-                }
-            }
-        },
         "camelcase": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+            "dev": true
         },
         "chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1952,6 +1133,7 @@
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
                     "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -1974,16 +1156,6 @@
                 "readdirp": "~3.6.0"
             }
         },
-        "ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-        },
-        "cli-boxes": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-            "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
-        },
         "cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1995,18 +1167,11 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
-        "clone-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-            "requires": {
-                "mimic-response": "^1.0.0"
-            }
-        },
         "color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -2014,31 +1179,14 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
-        },
-        "configstore": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-            "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-            "requires": {
-                "dot-prop": "^5.2.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^3.0.0",
-                "unique-string": "^2.0.0",
-                "write-file-atomic": "^3.0.0",
-                "xdg-basedir": "^4.0.0"
-            }
-        },
-        "crypto-random-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
         },
         "debug": {
             "version": "4.3.3",
@@ -2063,24 +1211,6 @@
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true
         },
-        "decompress-response": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-            "requires": {
-                "mimic-response": "^1.0.0"
-            }
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-        },
-        "defer-to-connect": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
-        },
         "diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -2093,42 +1223,17 @@
             "integrity": "sha512-IYZbgYthPTspgqYeciRJNPhSwL51yer7HAwDXhF5p+H7mTDbPvY3PCk/QDjNxdPCpWkaJVFC4t7iCNB/t9E5Kw==",
             "dev": true
         },
-        "dot-prop": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-            "requires": {
-                "is-obj": "^2.0.0"
-            }
-        },
-        "duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "requires": {
-                "once": "^1.4.0"
-            }
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
             "dev": true
-        },
-        "escape-goat": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
-            "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
         },
         "escape-string-regexp": {
             "version": "4.0.0",
@@ -2186,14 +1291,6 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
-        "get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "requires": {
-                "pump": "^3.0.0"
-            }
-        },
         "glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -2217,37 +1314,6 @@
                 "is-glob": "^4.0.1"
             }
         },
-        "global-dirs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-            "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-            "requires": {
-                "ini": "2.0.0"
-            }
-        },
-        "got": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "requires": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
-            }
-        },
-        "graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
         "growl": {
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -2257,33 +1323,14 @@
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "has-yarn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-            "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true
         },
         "he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
-        },
-        "http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
-        "import-lazy": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "inflight": {
             "version": "1.0.6",
@@ -2301,11 +1348,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "ini": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
-        },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2313,14 +1355,6 @@
             "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
-            }
-        },
-        "is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-            "requires": {
-                "ci-info": "^2.0.0"
             }
         },
         "is-extglob": {
@@ -2332,7 +1366,8 @@
         "is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true
         },
         "is-glob": {
             "version": "4.0.3",
@@ -2343,35 +1378,11 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-installed-globally": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-            "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-            "requires": {
-                "global-dirs": "^3.0.0",
-                "is-path-inside": "^3.0.2"
-            }
-        },
-        "is-npm": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
-            "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA=="
-        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-obj": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
-        },
-        "is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
         },
         "is-plain-obj": {
             "version": "2.1.0",
@@ -2379,21 +1390,11 @@
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
-        },
-        "is-yarn-global": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-            "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
         },
         "isexe": {
             "version": "2.0.0",
@@ -2408,27 +1409,6 @@
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
-            }
-        },
-        "json-buffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-        },
-        "keyv": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-            "requires": {
-                "json-buffer": "3.0.0"
-            }
-        },
-        "latest-version": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-            "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-            "requires": {
-                "package-json": "^6.3.0"
             }
         },
         "locate-path": {
@@ -2450,39 +1430,6 @@
                 "is-unicode-supported": "^0.1.0"
             }
         },
-        "lowercase-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-        },
-        "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "requires": {
-                "yallist": "^4.0.0"
-            }
-        },
-        "make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "requires": {
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
-            }
-        },
-        "mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-        },
         "minami": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/minami/-/minami-1.2.3.tgz",
@@ -2497,11 +1444,6 @@
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
-        },
-        "minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "mocha": {
             "version": "9.2.0",
@@ -2560,23 +1502,14 @@
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
         },
-        "normalize-url": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-            "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
-        },
-        "p-cancelable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
         },
         "p-limit": {
             "version": "3.1.0",
@@ -2594,24 +1527,6 @@
             "dev": true,
             "requires": {
                 "p-limit": "^3.0.2"
-            }
-        },
-        "package-json": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-            "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-            "requires": {
-                "got": "^9.6.0",
-                "registry-auth-token": "^4.0.0",
-                "registry-url": "^5.0.0",
-                "semver": "^6.2.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
             }
         },
         "path-exists": {
@@ -2632,28 +1547,6 @@
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true
         },
-        "prepend-http": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-        },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "pupa": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
-            "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
-            "requires": {
-                "escape-goat": "^2.0.0"
-            }
-        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2661,29 +1554,6 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "dependencies": {
-                "ini": {
-                    "version": "1.3.8",
-                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-                    "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-                }
             }
         },
         "readdirp": {
@@ -2695,64 +1565,17 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "registry-auth-token": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-            "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
-            "requires": {
-                "rc": "^1.2.8"
-            }
-        },
-        "registry-url": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-            "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-            "requires": {
-                "rc": "^1.2.8"
-            }
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
-        "responselike": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-            "requires": {
-                "lowercase-keys": "^1.0.0"
-            }
-        },
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true
-        },
-        "semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
-        },
-        "semver-diff": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-            "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-            "requires": {
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
-            }
         },
         "serialize-javascript": {
             "version": "6.0.0",
@@ -2763,15 +1586,11 @@
                 "randombytes": "^2.1.0"
             }
         },
-        "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        },
         "string-width": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
             "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -2782,6 +1601,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
             "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.0"
             }
@@ -2807,11 +1627,6 @@
             "integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ=",
             "dev": true
         },
-        "to-readable-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-        },
         "to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2826,61 +1641,11 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
-        "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
-        },
-        "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
-        },
         "typescript": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
             "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
             "dev": true
-        },
-        "unique-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-            "requires": {
-                "crypto-random-string": "^2.0.0"
-            }
-        },
-        "update-notifier": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
-            "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
-            "requires": {
-                "boxen": "^5.0.0",
-                "chalk": "^4.1.0",
-                "configstore": "^5.0.1",
-                "has-yarn": "^2.1.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^2.0.0",
-                "is-installed-globally": "^0.4.0",
-                "is-npm": "^5.0.0",
-                "is-yarn-global": "^0.3.0",
-                "latest-version": "^5.1.0",
-                "pupa": "^2.1.1",
-                "semver": "^7.3.4",
-                "semver-diff": "^3.1.1",
-                "xdg-basedir": "^4.0.0"
-            }
-        },
-        "url-parse-lax": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-            "requires": {
-                "prepend-http": "^2.0.0"
-            }
         },
         "webidl-conversions": {
             "version": "3.0.1",
@@ -2905,14 +1670,6 @@
                 "isexe": "^2.0.0"
             }
         },
-        "widest-line": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-            "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-            "requires": {
-                "string-width": "^4.0.0"
-            }
-        },
         "workerpool": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
@@ -2923,6 +1680,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -2932,34 +1690,14 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "write-file-atomic": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-            "requires": {
-                "imurmurhash": "^0.1.4",
-                "is-typedarray": "^1.0.0",
-                "signal-exit": "^3.0.2",
-                "typedarray-to-buffer": "^3.1.5"
-            }
-        },
-        "xdg-basedir": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yargs": {
             "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "dependencies": {
         "@sapphire/async-queue": "^1.1.4",
         "ms": "^2.1.3",
-        "node-fetch": "^2.6.7",
-        "update-notifier": "^5.1.0"
+        "node-fetch": "^2.6.7"
     },
     "engines": {
         "node": ">=14"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const pkg = require("../package.json")
+
 module.exports = {
     version: pkg.version,
     AmariBot: require("./AmariBot"),

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
-const updateNotifier = require("update-notifier")
-const pkg = require("../package.json")
-updateNotifier({ pkg }).notify()
-
 module.exports = {
     version: pkg.version,
     AmariBot: require("./AmariBot"),


### PR DESCRIPTION
The update-notifier package has vulnerabilities, and `npm audit fix` can't do anything about it. It would be better to remove the dependency so our package isn't vulnerable anymore.

The update-notifier dependency doesn't even seem to work, especially since I don't see an update alert when I'm on an outdated version.