### PR TITLE
Fix getCombinedLeaderboard not returning weekly

### DIFF
--- a/src/AmariBot.ts
+++ b/src/AmariBot.ts
@@ -91,7 +91,7 @@ export class AmariBot {
 		// combine the two leaderboards
 		const combinedLeaderboard = mainLeaderboard.data.map((x) => {
 			const weeklyData = weeklyLeaderboard.data.find((y) => y.id === x.id)
-			const user: APIUser = { weeklyExp: weeklyData?.exp || 0, ...x }
+			const user: APIUser = { ...x, weeklyExp: weeklyData?.exp ?? 0 }
 			return user
 		})
 


### PR DESCRIPTION
Putting ...x after weeklyExp was overwriting weeklyExp with null because x contains a value, weeklyExp, which is always null because that's how the API returns it. It overwrites the field with this value, thus making the function return exactly the same output as getRawLeaderboard.